### PR TITLE
Added relaxed security for debug=True

### DIFF
--- a/django_twilio/decorators.py
+++ b/django_twilio/decorators.py
@@ -12,63 +12,65 @@ from twilio.twiml import Verb
 from twilio.util import RequestValidator
 
 def twilio_view(f):
-	"""This decorator provides several helpful shortcuts for writing twilio
-	views.
+    """This decorator provides several helpful shortcuts for writing twilio
+    views.
 
-		- It ensures that only requests from twilio are passed through. This
-		  helps protect you from forged requests.
+        - It ensures that only requests from twilio are passed through. This
+          helps protect you from forged requests.
 
-		- It ensures  your view is exempt from CSRF checks via Django's
-		  @csrf_exempt decorator. This is necessary for any view that accepts
-		  POST requests from outside the local domain (eg: twilio's servers).
+        - It ensures  your view is exempt from CSRF checks via Django's
+          @csrf_exempt decorator. This is necessary for any view that accepts
+          POST requests from outside the local domain (eg: twilio's servers).
 
-		- It allows your view to (optionally) return TwiML to pass back to
-		  twilio's servers instead of building a HttpResponse object manually.
+        - It allows your view to (optionally) return TwiML to pass back to
+          twilio's servers instead of building a HttpResponse object manually.
 
-		  .. note::
-			At this time this ONLY supports XML TwiML since the twilio
-			library only supports XML rendering at the moment. In future
-			releases this may be changed to support JSON (and other formats) as
-			well.
+          .. note::
+            At this time this ONLY supports XML TwiML since the twilio
+            library only supports XML rendering at the moment. In future
+            releases this may be changed to support JSON (and other formats) as
+            well.
 
-	Usage::
+    Usage::
 
-		from twilio import Response, Sms
+        from twilio import Response, Sms
 
-		@twilio_view
-		def my_view(request):
-			r = Response()
-			r.append(Sms('Thanks for the SMS message!'))
-			return r
-	"""
-	@csrf_exempt
-	@require_POST
-	@wraps(f)
-	def decorator(request, *args, **kwargs):
-		# Here we'll use the twilio library's request validation code to ensure
-		# that the current request actually came from twilio, and isn't a
-		# forgery. If it is a forgery, then we'll return a HTTP 403 error
-		# (forbidden).
-		try:
-			url = request.build_absolute_uri()
-			signature = request.META['HTTP_X_TWILIO_SIGNATURE']
-		except (AttributeError, KeyError):
-			return HttpResponseForbidden()
+        @twilio_view
+        def my_view(request):
+            r = Response()
+            r.append(Sms('Thanks for the SMS message!'))
+            return r
+    """
+    @csrf_exempt
+    @wraps(f)
+    def decorator(request, *args, **kwargs):
+        # Here we'll use the twilio library's request validation code to ensure
+        # that the current request actually came from twilio, and isn't a
+        # forgery if settings.DEBUG is True. If it is a forgery, then we'll
+        #return a HTTP 403 error (forbidden).
+        if not settings.DEBUG:
+            try:
+                url = request.build_absolute_uri()
+                signature = request.META['HTTP_X_TWILIO_SIGNATURE']
+            except (AttributeError, KeyError):
+                return HttpResponseForbidden()
+    
+            validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
+            if not validator.validate(url, request.POST, signature):
+                return HttpResponseForbidden()
+    
+            # Run the wrapped view, and capture the data returned.
+            response = require_POST(f(request, *args, **kwargs))
+        else:
+            response = f(request, *args, **kwargs)
 
-		validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
-		if not validator.validate(url, request.POST, signature):
-			return HttpResponseForbidden()
-
-		# Run the wrapped view, and capture the data returned.
-		response = f(request, *args, **kwargs)
-
-		# If the view returns a string, we'll assume it is XML TwilML data and
-		# pass it back with the appropriate mimetype. We won't check the XML
-		# data because that would be too time consuming for every request.
-		# Instead, we'll let the errors pass through to be dealt with by the
-		# developer.
-		if isinstance(response, Verb):
-			return HttpResponse(response, mimetype='text/xml')
-		else:
-			return response
-	return decorator
+        # If the view returns a string, we'll assume it is XML TwilML data and
+        # pass it back with the appropriate mimetype. We won't check the XML
+        # data because that would be too time consuming for every request.
+        # Instead, we'll let the errors pass through to be dealt with by the
+        # developer.
+        if isinstance(response, Verb):
+            return HttpResponse(response, mimetype='text/xml')
+        else:
+            return response
+    return decorator

--- a/django_twilio/tests.py
+++ b/django_twilio/tests.py
@@ -1,6 +1,7 @@
 """Test suite for django-twilio."""
 
 
+from django.conf import settings
 from django.test import TestCase
 from django.http import HttpRequest, HttpResponse
 
@@ -8,63 +9,75 @@ from .decorators import twilio_view
 
 
 class TwilioViewTestCase(TestCase):
-	"""Run tests against the twilio_view decorator."""
+    """Run tests against the twilio_view decorator."""
 
-	def setUp(self):
-		"""Create some test helpers."""
+    def setUp(self):
+        """Create some test helpers."""
 
-		def test_view_that_returns_str(request):
-			"""A simple test view that returns a string."""
-			return '<Response><Sms>Hi!</Sms></Response>'
-		self.str_view = test_view_that_returns_str
+        def test_view_that_returns_str(request):
+            """A simple test view that returns a string."""
+            return '<Response><Sms>Hi!</Sms></Response>'
+        self.str_view = test_view_that_returns_str
 
-		def test_view_that_returns_httpresponse(request):
-			"""A simple test view that returns a HttpResponse object."""
-			return HttpResponse('<Response><Sms>Hi!</Sms></Response>',
-					mimetype='text/xml')
-		self.response_view = test_view_that_returns_httpresponse
+        def test_view_that_returns_httpresponse(request):
+            """A simple test view that returns a HttpResponse object."""
+            return HttpResponse('<Response><Sms>Hi!</Sms></Response>',
+                    mimetype='text/xml')
+        self.response_view = test_view_that_returns_httpresponse
 
-		# These are fake HttpRequest objects that we'll use to mimick twilio
-		# responses.
-		self.request_get = HttpRequest()
-		self.request_get.method = 'GET'
-		self.request_post = HttpRequest()
-		self.request_post.method = 'POST'
+        # These are fake HttpRequest objects that we'll use to mimick twilio
+        # responses.
+        self.request_get = HttpRequest()
+        self.request_get.method = 'GET'
+        self.request_post = HttpRequest()
+        self.request_post.method = 'POST'
 
-	def test_forgery_returns_forbidden(self):
-		"""Ensure that forged twilio requests are dealt with properly."""
-		response = twilio_view(self.str_view)(self.request_post)
-		self.assertEquals(response.status_code, 403)
+    def test_forgery_returns_forbidden(self):
+        """Ensure that forged twilio requests are dealt with properly."""
+        debug_orig = settings.DEBUG
+        settings.DEBUG = False
+        response = twilio_view(self.response_view)(self.request_post)
+        self.assertEquals(response.status_code, 403)
+        settings.DEBUG = True
+        response = twilio_view(self.response_view)(self.request_post)
+        self.assertEquals(response.status_code, 200)
+        settings.DEBUG = debug_orig
 
-	def test_forgery_check_allows_real_requests(self):
-		"""Ensure that real twilio requests are allowed through."""
-		pass
+    def test_forgery_check_allows_real_requests(self):
+        """Ensure that real twilio requests are allowed through."""
+        pass
 
-	def test_is_csrf_exempt(self):
-		"""Ensure a wrapped view is exempt from CSRF checks."""
-		response = twilio_view(self.str_view)(self.request_post)
-		self.assertTrue(response.csrf_exempt)
+    def test_is_csrf_exempt(self):
+        """Ensure a wrapped view is exempt from CSRF checks."""
+        response = twilio_view(self.str_view)(self.request_post)
+        self.assertTrue(response.csrf_exempt)
 
-	def test_allows_post(self):
-		"""Ensure a wrapped view accepts POST requests."""
-		response = twilio_view(self.str_view)(self.request_post)
-		self.assertTrue(response.status_code != 405)
+    def test_allows_post(self):
+        """Ensure a wrapped view accepts POST requests."""
+        response = twilio_view(self.str_view)(self.request_post)
+        self.assertTrue(response.status_code != 405)
 
-	def test_requires_post(self):
-		"""Ensure a wrapped view requires POST requests."""
-		response = twilio_view(self.str_view)(self.request_get)
-		self.assertEquals(response.status_code, 405)
+    def test_requires_post(self):
+        """Ensure a wrapped view requires POST requests."""
+        debug_orig = settings.DEBUG
+        settings.DEBUG = False
+        response = twilio_view(self.response_view)(self.request_get)
+        self.assertEquals(response.status_code, 403)
+        settings.DEBUG = True
+        response = twilio_view(self.response_view)(self.request_get)
+        self.assertEquals(response.status_code, 200)
+        settings.DEBUG = debug_orig
 
-	def test_httpresponse_pass_through(self):
-		"""Ensure that if a wrapped view returns a HttpResponse object then we
-		don't modify the response.
-		"""
-		response = twilio_view(self.response_view)(self.request_post)
-		self.assertTrue(isinstance(response, HttpResponse))
+    def test_httpresponse_pass_through(self):
+        """Ensure that if a wrapped view returns a HttpResponse object then we
+        don't modify the response.
+        """
+        response = twilio_view(self.response_view)(self.request_post)
+        self.assertTrue(isinstance(response, HttpResponse))
 
-	def test_str_is_modified(self):
-		"""Ensure that we create a HttpResponse object for the developer if the
-		wrapped view returns a string.
-		"""
-		response = twilio_view(self.str_view)(self.request_post)
-		self.assertTrue(isinstance(response, HttpResponse))
+    def test_str_is_modified(self):
+        """Ensure that we create a HttpResponse object for the developer if the
+        wrapped view returns a string.
+        """
+        response = twilio_view(self.str_view)(self.request_post)
+        self.assertTrue(isinstance(response, HttpResponse))


### PR DESCRIPTION
I was having quite a time trying to build and test locally so I modified the decorator to only enforce post and authenticate the request if debug is false.

It looks like my editor messed with the entire file... Did you use tabs instead of 4 spaces intentionally?
