### PR TITLE
Validate against originally requested url

### DIFF
--- a/django_twilio/decorators.py
+++ b/django_twilio/decorators.py
@@ -82,6 +82,11 @@ def twilio_view(f):
             try:
                 validator = RequestValidator(django_twilio_settings.TWILIO_AUTH_TOKEN)
                 url = request.build_absolute_uri()
+                # Ensure the original requested url is tested for validation
+                # Prevents breakage when processed behind a proxy server
+                if 'HTTP_X_FORWARDED_SERVER' in request.META:
+                    protocol = 'https' if request.META['HTTP_X_TWILIO_SSL'] == 'Enabled' else 'http'
+                    url = "%s://%s%s" % ( protocol, request.META['HTTP_X_FORWARDED_SERVER'], request.META['REQUEST_URI']) 
                 signature = request.META['HTTP_X_TWILIO_SIGNATURE']
             except (AttributeError, KeyError):
                 return HttpResponseForbidden()


### PR DESCRIPTION
Adds a check to validation against the originally requested url, instead of the currently processing url.

This should issue #13 as I run this in production behind a proxy and over ssl.
