### PR TITLE
uses Django's own build_absolute_uri method, even when proxified

### DIFF
--- a/django_twilio/decorators.py
+++ b/django_twilio/decorators.py
@@ -81,11 +81,6 @@ def twilio_view(f):
             try:
                 validator = RequestValidator(django_twilio_settings.TWILIO_AUTH_TOKEN)
                 url = request.build_absolute_uri()
-                # Ensure the original requested url is tested for validation
-                # Prevents breakage when processed behind a proxy server
-                if 'HTTP_X_FORWARDED_SERVER' in request.META:
-                    protocol = 'https' if request.META['HTTP_X_TWILIO_SSL'] == 'Enabled' else 'http'
-                    url = "%s://%s%s" % ( protocol, request.META['HTTP_X_FORWARDED_SERVER'], request.META['REQUEST_URI']) 
                 signature = request.META['HTTP_X_TWILIO_SIGNATURE']
             except (AttributeError, KeyError):
                 return HttpResponseForbidden()


### PR DESCRIPTION
As discussed in the issue #13, the test introduced in the PR #17 does not work with my production env where request.META['REQUEST_URI'] is non-existent.

Django already has the relevant information built in request.build_absolute_uri() - at least in Django 1.4.x :

https://github.com/django/django/blob/stable/1.4.x/django/http/__init__.py
- the http/https is already handled by `HttpRequest.is_secure()`
- the host/domain name is provided by `HttpRequest.get_host()` and it's
     already proxy-compatible with HTTP_X_FORWARDED_HOST
- the document path is processed by `HttpRequest.path`

I would suggest that we go back to the standard Django way of computing the original url.
