### PR TITLE
Add setting to explicitly enable/disable forgery protection.

### DIFF
--- a/django_twilio/decorators.py
+++ b/django_twilio/decorators.py
@@ -64,9 +64,11 @@ def twilio_view(f):
             assert len(args) >= 1
             request = args[0]
 
-        # Turn off Twilio authentication when in debug mode otherwise
-        # things do not work properly. For more information see the docs
-        if not settings.DEBUG:
+        # Turn off Twilio authentication when explicitly requested, or in debug mode.
+        # Otherwise things do not work properly. For more information see the docs.
+        use_forgery_protection = (
+            getattr(settings, 'DJANGO_TWILIO_FORGERY_PROTECTION', not settings.DEBUG))
+        if use_forgery_protection:
 
             if request.method not in methods:
                 return HttpResponseNotAllowed(request.method)

--- a/django_twilio/tests/decorators.py
+++ b/django_twilio/tests/decorators.py
@@ -5,6 +5,7 @@ from base64 import encodestring
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import Client, RequestFactory, TestCase
+from django.test.utils import override_settings
 
 from twilio.twiml import Response
 
@@ -149,3 +150,23 @@ class TwilioViewTestCase(TestCase):
         request = self.factory.post(
             self.response_uri, HTTP_X_TWILIO_SIGNATURE=self.response_signature)
         self.assertTrue(isinstance(response_view(request), HttpResponse))
+
+    def test_override_forgery_protection_off_debug_off(self):
+        with override_settings(DJANGO_TWILIO_FORGERY_PROTECTION=False, DEBUG=False):
+            request = self.factory.post(self.str_uri)
+            self.assertEquals(str_view(request).status_code, 200)
+
+    def test_override_forgery_protection_off_debug_on(self):
+        with override_settings(DJANGO_TWILIO_FORGERY_PROTECTION=False, DEBUG=True):
+            request = self.factory.post(self.str_uri)
+            self.assertEquals(str_view(request).status_code, 200)
+
+    def test_override_forgery_protection_on_debug_off(self):
+        with override_settings(DJANGO_TWILIO_FORGERY_PROTECTION=True, DEBUG=False):
+            request = self.factory.post(self.str_uri)
+            self.assertEquals(str_view(request).status_code, 403)
+
+    def test_override_forgery_protection_on_debug_on(self):
+        with override_settings(DJANGO_TWILIO_FORGERY_PROTECTION=True, DEBUG=True):
+            request = self.factory.post(self.str_uri)
+            self.assertEquals(str_view(request).status_code, 403)


### PR DESCRIPTION
This is one possible way to implement the idea I was talking about in issue #48. All of the existing tests pass with no modifications, and I added a few new ones to demonstrate how the new setting works.

This is fully backwards compatible with the current release, but adds additional flexibility for those who want it.
