### PR TITLE
Django 1.7 BooleanField default changed to None

### DIFF
--- a/django_twilio/models.py
+++ b/django_twilio/models.py
@@ -15,7 +15,7 @@ class Caller(models.Model):
         <http://en.wikipedia.org/wiki/E.164>`_ format.
 
     """
-    blacklisted = models.BooleanField()
+    blacklisted = models.BooleanField(default=False)
     phone_number = PhoneNumberField(unique=True)
 
     def __unicode__(self):


### PR DESCRIPTION
Django 1.6 BooleanField default value is False. This ensures that
Django 1.7 system check warnings get silenced.
