### PR TITLE
Fixed Typo In Docs

### DIFF
--- a/docs/source/requests.rst
+++ b/docs/source/requests.rst
@@ -17,7 +17,7 @@ Here is an example::
     from twilio import twiml
     from django_twilio.decorators import twilio_view
     # include decompose in your views.py
-    from django_twilio.requests import decompose
+    from django_twilio.request import decompose
 
     @twilio_view
     def inbound_view(request):


### PR DESCRIPTION
It's django_twilio.request, not django_twilio.requests