### PR TITLE
fix typo for twiml.response()

### DIFF
--- a/docs/source/requests.rst
+++ b/docs/source/requests.rst
@@ -22,7 +22,7 @@ Here is an example::
     @twilio_view
     def inbound_view(request):
 
-        response = twiml.response()
+        response = twiml.Response()
 
         # Create a new TwilioRequest object
         twilio_request = decompose(request)


### PR DESCRIPTION
I fixed a typo that I found because I copied and pasted the code from this page :)

the line should read:
response = twiml.Response() 

instead of
response = twiml.response()

Note the capitalization.