### PR TITLE
Minimal changes to work with latest Twilio

### DIFF
--- a/django_twilio/decorators.py
+++ b/django_twilio/decorators.py
@@ -13,8 +13,8 @@ from django.views.decorators.csrf import csrf_exempt
 from django.http import (
     HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseNotAllowed)
 
-from twilio.twiml import Verb
-from twilio.util import RequestValidator
+from twilio.twiml import TwiML as Verb
+from twilio.request_validator import RequestValidator
 
 from .settings import TWILIO_AUTH_TOKEN
 from .utils import get_blacklisted_response


### PR DESCRIPTION
It appears the Verb was renamed in [this commit](https://github.com/twilio/twilio-python/commit/0af4776a961a5b0fef8052082fb1f4027cff172e), and the RequestValidator was moved in [this commit](https://github.com/twilio/twilio-python/commit/c0d97197109ce269cb7ab5c5e993fb6648dbf4cf).

Note: This is not backward-compatible with older versions of Twilio!