### PR TITLE
adding labels to silence missing label warning for django 1.9

### DIFF
--- a/django_twilio/models.py
+++ b/django_twilio/models.py
@@ -31,6 +31,8 @@ class Caller(models.Model):
             blacklist_status=' (blacklisted)' if self.blacklisted else '',
         )
 
+    class Meta():
+        app_label = 'django_twilio'
 
 @python_2_unicode_compatible
 class Credential(models.Model):
@@ -58,3 +60,6 @@ class Credential(models.Model):
     account_sid = models.CharField(max_length=34)
 
     auth_token = models.CharField(max_length=32)
+
+    class Meta():
+        app_label = 'django_twilio'


### PR DESCRIPTION
Getting deprecation warnings with Django. Adding the App labels seems to have fixed it. 

![screen shot 2017-07-13 at 1 18 31 pm](https://user-images.githubusercontent.com/19435085/28186451-0f3962c0-67d0-11e7-906a-9686317bceb3.png)
