### PR TITLE
updated the doc examples for latest Twilio package updates

### DIFF
--- a/docs/source/decorators.rst
+++ b/docs/source/decorators.rst
@@ -38,12 +38,12 @@ Example usage
 
 Let's take a look at an example::
 
-    from twilio import twiml
+    from twilio.twiml.messaging_response import MessagingResponse
     from django_twilio.decorators import twilio_view
 
     @twilio_view
     def reply_to_sms_messages(request):
-        r = twiml.Response()
+        r = MessagingResponse()
         r.message('Thanks for the SMS message!')
         return r
 
@@ -57,7 +57,7 @@ Class based view example
 
 Here's the same thing as above, using a class-based view::
 
-    from twilio import twiml
+    from twilio.twiml.messaging_response import MessagingResponse
 
     from django.views.generic import View
     from django.utils.decorators import method_decorator
@@ -71,7 +71,7 @@ Here's the same thing as above, using a class-based view::
             return super(ResponseView, self).dispatch(request, *args, **kwargs)
 
         def post(self, request):
-            r = twiml.Response()
+            r = MessagingResponse()
             r.message('Thanks for the SMS message!')
             return r
 

--- a/docs/source/requests.rst
+++ b/docs/source/requests.rst
@@ -14,7 +14,7 @@ Example usage
 
 Here is an example::
 
-    from twilio import twiml
+    from twilio.twiml.messaging_response import MessagingResponse
     from django_twilio.decorators import twilio_view
     # include decompose in your views.py
     from django_twilio.request import decompose
@@ -22,7 +22,7 @@ Here is an example::
     @twilio_view
     def inbound_view(request):
 
-        response = twiml.Response()
+        response = MessagingResponse()
 
         # Create a new TwilioRequest object
         twilio_request = decompose(request)

--- a/docs/source/views.rst
+++ b/docs/source/views.rst
@@ -474,12 +474,12 @@ with just the built-in ``django_twilio.views.conference`` view::
     )
 
     # views.py
-    from twilio import twiml
+    from twilio.twiml.voice_response import VoiceResponse
     from django_twilio.decorators import twilio_view
 
     @twilio_view
     def say_hi(request):
-        r = twiml.Response()
+        r = VoiceResponse()
         r.say('Thanks for joining the conference! Django and Twilio rock!')
         return r
 


### PR DESCRIPTION
It looks like the newer versions of the [Twilio python library](https://github.com/twilio/twilio-python) have changed the `Response()` syntax a bit. Updated the docs to reflect the following:

- update `from twilio import twiml` to `twilio.twiml.messaging_response import MessagingResponse` for SMS
- update `from twilio import twiml` to `twilio.twiml.voice_response import VoiceResponse` for voice responses