### PR TITLE
Fix/test project urls admin

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -6,8 +6,17 @@ import sys
 
 # Django settings for test_project project.
 
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+from distutils.version import StrictVersion
+
+import django
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -18,6 +27,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'db.sqlite3',
     }
 }
 
@@ -85,23 +95,47 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'j1wd@qqodn-r9h&o@0jj!uw^#pm5wcdu2^cdsax=hm+-mk705p'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+# This is a temporary shim to allow the old style MIDDLEWARE_CLASSES to work
+# We will forge a plan to remove at least the unsupported versions soon.
+# Django 2.0 is the future, but 1.11 is still supported.
+# This test_project though is simple enough that the restrictions are small.
+if StrictVersion(django.__version__) < StrictVersion('2.0'):
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+else:
+    MIDDLEWARE = [
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    ]
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+ROOT_URLCONF = 'test_project.urls'
 
-ROOT_URLCONF = 'test_project.test_app.urls'
-
-TEMPLATE_DIRS = ()
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')]
+        ,
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -136,10 +170,6 @@ else:
 
 NOSE_ARGS = ['--with-coverage', '--cover-package=django_twilio']
 
-# Until South is once again Python 3 compatible,
-# skip testing migrations in Python 3
-if sys.version_info[0] == 3:
-    SOUTH_TESTS_MIGRATE = False
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/test_project/test_app/decorators.py
+++ b/test_project/test_app/decorators.py
@@ -20,8 +20,6 @@ from .views import (response_view, str_view, bytes_view, verb_view,
 
 class TwilioViewTestCase(TestCase):
 
-    urls = 'test_project.test_app.urls'
-
     def setUp(self):
 
         self.regular_caller = G(Caller, phone_number='+12222222222', blacklisted=False)

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -7,12 +7,12 @@ from . import views
 
 # Test URLs for our ``django_twilio.decorators`` module.
 urlpatterns = [
-    url(r'^test_app/decorators/response_view/$', views.response_view),
-    url(r'^test_app/decorators/response_class_view/$', views.ResponseView.as_view()),
-    url(r'^test_app/decorators/str_view/$', views.str_view),
-    url(r'^test_app/decorators/str_class_view/$', views.StrView.as_view()),
-    url(r'^test_app/decorators/bytes_view/$', views.bytes_view),
-    url(r'^test_app/decorators/bytes_class_view/$', views.BytesView.as_view()),
-    url(r'^test_app/decorators/verb_view/$', views.verb_view),
-    url(r'^test_app/decorators/verb_class_view/$', views.VerbView.as_view())
+    url(r'^decorators/response_view/$', views.response_view),
+    url(r'^decorators/response_class_view/$', views.ResponseView.as_view()),
+    url(r'^decorators/str_view/$', views.str_view),
+    url(r'^decorators/str_class_view/$', views.StrView.as_view()),
+    url(r'^decorators/bytes_view/$', views.bytes_view),
+    url(r'^decorators/bytes_class_view/$', views.BytesView.as_view()),
+    url(r'^decorators/verb_view/$', views.verb_view),
+    url(r'^decorators/verb_class_view/$', views.VerbView.as_view())
 ]

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    url(r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'^test_app/', include('test_project.test_app.urls')),
+]
+


### PR DESCRIPTION
Modernizes some of the test project settings and test project urls.

Unfortunately, django admin on python3 on test project doesn't seem to work.

@km-pg or anyone would you mind testing locally on python3, too? I get this when accessing the admin: `'WSGIRequest' object has no attribute 'user'`

I don't feel comfortable merging this change until all major python versions are compatible.


If you do test, you'll need to specify `--settings test_project.settings` to enable the test project to run. This will have to be done for all `python manage.py` commands.

This references issue #132 