### PR TITLE
adjust .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
 language: python
 
 python:
-    - '2.7'
-    - '3.4'
-    - '3.5'
-    - '3.6'
-    # travis ci doesn't have good py 3.7 support, yet.
-#    - '3.7'
-    - 'pypy'
-    - 'pypy3'
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy3
 
 env:
-    - DJANGO="django>=1.8,<1.9"
-    - DJANGO="django>=1.9,<1.10"
-    - DJANGO="django>=1.10,<1.11"
     - DJANGO="django>=1.11,<2"
     - DJANGO="django>=2.0,<2.1"
     - DJANGO="django>=2.1,<2.2"
@@ -27,30 +20,24 @@ script:
     - python manage.py test
 
 matrix:
-  exclude:
-    - python: "2.7"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "2.7"
-      env: DJANGO="django>=2.1,<2.2"
-    - python: "pypy"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "pypy"
-      env: DJANGO="django>=2.1,<2.2"
-    - python: "3.6"
-      env: DJANGO="django>=1.8,<1.9"
-    - python: "3.6"
-      env: DJANGO="django>=1.9,<1.10"
-    - python: "3.6"
-      env: DJANGO="django>=1.10,<1.11"
-    - python: "3.4"
-      env: DJANGO="django>=2.1,<2.2"
-    - python: "3.7"
-      env: DJANGO="django>=1.8,<1.9"
-    - python: "3.7"
-      env: DJANGO="django>=1.9,<1.10"
-    - python: "3.7"
-      env: DJANGO="django>=1.10,<1.11"
-    - python: "3.7"
+  include:
+    - python: 2.7
       env: DJANGO="django>=1.11,<2"
-    - python: "3.7"
+    - python: pypy
+      env: DJANGO="django>=1.11,<2"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: DJANGO="django>=1.11.17,<2"
+    - python: 3.7
+      dist: xenial
+      sudo: true
       env: DJANGO="django>=2.0,<2.1"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: DJANGO="django>=2.1,<2.2"
+  exclude:
+    - python: 3.4
+      env: DJANGO="django>=2.1,<2.2"
+


### PR DESCRIPTION
I refactored .travis.yml. Only testing with Python 2.7, 3.4, 3.5, 3.6, 3.7, pypy, and pypy3 and with Django 1.11, 2.0, and 2.1 in supported combinations. Dropped support for Django 1.8, 1.9, and 1.10 which aren't getting security updates.