### PR TITLE
Dependence missing on install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-phonenumber-field==0.6
 twilio>=6.3.0
 wheel>=0.22.0
 setuptools>=36.2
+phonenumbers>=8.10.22

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'setuptools>=36.2',
         'twilio>=6.3.0,<7',
         'django-phonenumber-field>=0.6',
+        'phonenumbers>8.10.22',
     ] + INSTALL_PYTHON_REQUIRES,
 
     # Metadata for PyPI:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'setuptools>=36.2',
         'twilio>=6.3.0,<7',
         'django-phonenumber-field>=0.6',
-        'phonenumbers>8.10.22',
+        'phonenumbers>=8.10.22',
     ] + INSTALL_PYTHON_REQUIRES,
 
     # Metadata for PyPI:


### PR DESCRIPTION
When you run python manage migrate you cant start django app because this dependence is missing