### PR TITLE
django 3.1 allowance in reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2.2,<3.1
+Django>=2.2,<3.2
 Sphinx>=1.2.0
 phonenumbers>=7.0.2
 django-phonenumber-field==2.4.0


### PR DESCRIPTION
Even though the change here is correct, unfortunately one of our dependencies (only in tests) has a breakage in that it uses an import which no longer remains in django 3.1.

That said, I'm going to merge this and release `0.13.1b1` and hopefully on the official release it'll be fixed.