### PR TITLE
update reference to obsolete TwilioRestClient

### DIFF
--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -39,7 +39,7 @@ Missing Settings
 ``TWILIO_ACCOUNT_SID`` and ``TWILIO_AUTH_TOKEN``, either as environment
 variables, or in your site's ``settings`` module. These are used to verify the
 legitimacy of HTTP requests to your Twilio views, and to instantiate the
-TwilioRestClient.
+``twilio.rest.Client``.
 
 If these variables are missing, ``django-twilio`` will raise HTTP 403
 (forbidden) errors, because it is unable to determine whether or not the HTTP

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -111,9 +111,9 @@ You can create a Credential object to store your variables if you want to use
 multiple Twilio accounts or provide your users with Twilio compatibility.
 
 When you want to use the credentials in a Credential object you need to manually
-build a TwilioRestClient like so::
+build a ``twilio.rest.Client`` like so::
 
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
     from django_twilio.utils import discover_twilio_credentials
 
     from django.contrib.auth.models import User
@@ -123,4 +123,4 @@ build a TwilioRestClient like so::
     account_sid, auth_token = discover_twilio_credentials(my_user)
 
     # Here we'll build a new Twilio_client with different credentials
-    twilio_client = TwilioRestClient(account_sid, auth_token)
+    twilio_client = Client(account_sid, auth_token)

--- a/docs/source/rest.rst
+++ b/docs/source/rest.rst
@@ -25,14 +25,14 @@ If you are using the `Twilio python library
 ``django-twilio``), you could see a list of all the phone numbers you have
 provisioned to your Twilio account by running the following code::
 
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
 
 
     # Your private Twilio API credentials.
     ACCOUNT_SID = 'xxx'
     AUTH_TOKEN = 'xxx'
 
-    client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
+    client = Client(ACCOUNT_SID, AUTH_TOKEN)
     for number in client.incoming_phone_numbers.stream():
         print(number.friendly_name)
 
@@ -42,14 +42,14 @@ engineering by making you manually specify your account credentials.
 
 Since ``django-twilio`` already requires you to enter your Twilio credentials in
 your ``settings.py`` file, ``django-twilio`` provides a simple wrapper around
-``TwilioRestClient``: ``django_twilio.client.twilio_client``.
+``Client``: ``django_twilio.client.twilio_client``.
 
 
 The ``twilio_client`` Wrapper
 -----------------------------
 
 As mentioned in the previous section, ``django-twilio`` ships with an
-instantiated ``TwilioRestClient``, so that you can use the `Twilio REST API
+instantiated ``twilio.rest.Client``, so that you can use the `Twilio REST API
 <https://twilio.github.io/twilio-python>`_ with
 as little effort as possible. :)
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     # Basic package information:
     name='django-twilio',
-    version='0.13.1.b2',
+    version='0.13.1',
     packages=find_packages(),
 
     # Packaging options:


### PR DESCRIPTION
updates reference in docs to obsolete ``twilio.rest.TwilioRestClient`` to ``twilio.rest.Client``.

Fixes #192 