### PR TITLE
django 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 2.2.8, 2.2.17, 3.0, 3.1, 3.2]
-        exclude:
-          - python-version: 3.8
-            django-version: 2.2
-          - python-version: 3.9
-            django-version: 2.2
-          - python-version: 3.9
-            django-version: 2.2.8
+        python-version: [3.8, 3.9, "3.10"]
+        django-version: [4.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
         python -m pip install -e .
     - name: Run Tests
       run: |
-        python -m manage test
+        pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = test_project.settings
+python_files = test_project/test_app/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django>=2.2,<3.3
+Django>=2.2,<4.1
 Sphinx>=1.2.0
 phonenumbers>=7.0.2
-django-phonenumber-field==2.4.0
+django-phonenumber-field==6.1.0
 twilio>=6.3.0
 wheel>=0.22.0
 setuptools>=36.2

--- a/setup.py
+++ b/setup.py
@@ -9,25 +9,9 @@ import sys
 INSTALL_PYTHON_REQUIRES = []
 # We are intending to keep up to date with the supported Django versions.
 # For the official support, please visit:
-# https://docs.djangoproject.com/en/3.2/faq/install/#what-python-version-can-i-use-with-django and you may change the version in the URL to suit your needs, and we will try to update that here too as we upgrade with django.
-if sys.version_info[1] == 5:
-    django_python_version_install = 'Django>=2.2,<3.0',
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
-elif sys.version_info[1] == 6:
-    django_python_version_install = 'Django>=2.2,<3.3',
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
-elif sys.version_info[1] == 7:
-    django_python_version_install = 'Django>=2.2,<3.3'
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
-elif sys.version_info[1] == 8:
-    django_python_version_install = 'Django>=2.2.8,<3.3'
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
-elif sys.version_info[1] == 9:
-    # slightly too broad (3.0.11 for v3.0, and 3.1.3 for v3.1) -- may need to fix
-    django_python_version_install = 'Django>=2.2.17,<3.3'
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
-elif sys.version_info[1] == 10:
-    django_python_version_install = 'Django>=3.2.9,<3.3'
+# https://docs.djangoproject.com/en/4.0/faq/install/#what-python-version-can-i-use-with-django
+if sys.version_info[1] in [8, 9, 10]:
+    django_python_version_install = "Django>=4.0,<4.1"
     INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
 
 setup(
@@ -68,17 +52,13 @@ setup(
     },
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',
         'License :: Public Domain',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -8,9 +8,9 @@ import sys
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-from distutils.version import StrictVersion
 
 import django
+import packaging.version
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -98,7 +98,7 @@ SECRET_KEY = 'j1wd@qqodn-r9h&o@0jj!uw^#pm5wcdu2^cdsax=hm+-mk705p'
 # We will forge a plan to remove at least the unsupported versions soon.
 # Django 2.0 is the future, but 1.11 is still supported.
 # This test_project though is simple enough that the restrictions are small.
-if StrictVersion(django.__version__) < StrictVersion('2.0'):
+if packaging.version.Version(django.__version__) < packaging.version.Version('2.0'):
     MIDDLEWARE_CLASSES = (
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
@@ -147,18 +147,9 @@ INSTALLED_APPS = (
     'django.contrib.admindocs',
 
 
-    # Use django-nose for running our tests:
-    'django_nose',
-
     # django-twilio, of course!
     'django_twilio',
 )
-
-# Nose test settings.
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = ['--with-coverage', '--cover-package=django_twilio']
-
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
-coverage==4.5.4
-django-dynamic-fixture==3.1.1
+coverage==6.3.2
+django-dynamic-fixture==3.1.2
 django-nose==1.4.7
+pytest-django==4.5.2
 flake8==4.0.1
 ipdb==0.13.9
 ipython==8.1.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage==4.5.4
 django-dynamic-fixture==3.1.1
-django-nose==1.4.6
-flake8==3.7.9
-ipdb==0.12.2
-ipython==7.16.3
+django-nose==1.4.7
+flake8==4.0.1
+ipdb==0.13.9
+ipython==8.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,py310
+envlist = py38,py39,py310
 [testenv]
 deps =
     -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ deps =
     -rrequirements.txt
     -rtest_requirements.txt
 commands=
-    python manage.py test
+    pytest


### PR DESCRIPTION
Closes #205

django phonenumber field does not have a release supporting django 4.0, so hopefully we are not burdened by that for too long. We may get lucky and nothing actually breaks, and then we can decide to make an official release or see what to do if it does break.