### PR TITLE
Allow twilio-python 8+ in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Django>=2.2,<4.3
 Sphinx>=1.2.0
 phonenumbers>=7.0.2
 django-phonenumber-field==6.1.0
-twilio>=6.3.0
+twilio>=7
 wheel>=0.22.0
 setuptools>=36.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Package dependencies:
     install_requires=[
         'setuptools>=36.2',
-        'twilio>=7,<8',
+        'twilio>=7',
         'django-phonenumber-field>=0.6',
         'phonenumbers>=8.10.22',
     ] + INSTALL_PYTHON_REQUIRES,


### PR DESCRIPTION
refs #233 

- Removes <8 constraint on twilio-python version
- Makes requirements version match setup.py