### PR TITLE
Fix `py_minor_version` check in setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
+      # Keep Django installation last in order to surface version conflicts.
       run: |
         python -m pip install --upgrade pip
-        python -m pip install django==${{ matrix.django-version }}
         python -m pip install -r requirements.txt
         python -m pip install -r test_requirements.txt
         python -m pip install -e .
+        python -m pip install django==${{ matrix.django-version }}
     - name: Run Tests
       run: |
         pytest

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_PYTHON_REQUIRES = []
 # We are intending to keep up to date with the supported Django versions.
 # For the official support, please visit:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-if py_minor_version := sys.version_info[1] in [8, 9, 10, 11]:
+if (py_minor_version := sys.version_info.minor) in [8, 9, 10, 11]:
     django_python_version_install = (
         f"Django>=4.0,<{'6' if py_minor_version >= 10 else '5'}"
     )


### PR DESCRIPTION
Fix for bug introduced in https://github.com/rdegges/django-twilio/pull/240

The `in` operator preceded the walrus operator resulting in the comparison being `True >= 10` and still pinning the Django version to <5 regardless of python version. The parentheses added fix this problem, and I used the `minor` attribute instead of index for readability.

The build didn't catch this because the installation of django-twilio came after the installation of django at the specified version, which was uninstalling django and reinstalling a compatible version. I rearranged the build so that this problem is demonstrated when it occurs.