### PR TITLE
docs: fix link to twilio python library

### DIFF
--- a/docs/source/foreword.rst
+++ b/docs/source/foreword.rst
@@ -55,7 +55,7 @@ describes the architecture and API flow that all of your applications will be
 using, and that ``django-twilio`` will help to abstract.
 
 ``django-twilio`` also depends on the official `Twilio python library
-<http://readthedocs.org/docs/twilio-python/en/latest/>`_, so you may want to
+<https://www.twilio.com/docs/libraries/reference/twilio-python/>`_, so you may want to
 familiarize yourself with their docs before continuing so you have a good idea
 of how things work.
 


### PR DESCRIPTION
The old link leads to the wrong place:

<img width="1167" height="353" alt="image" src="https://github.com/user-attachments/assets/3cc56eff-0503-4c86-86e6-0cbf51965405" />

I replaced it with a new right one.