### PR TITLE
Add support for Django 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,19 +9,19 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
-        django-version: [4.0, 4.1, 4.2, "5.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.1", "5.2", "6.0"]
         exclude:
-          # Django 5 requires python>=3.10
-          - python-version: 3.8
-            django-version: "5.0"
-          - python-version: 3.9
-            django-version: "5.0"
+          # Django 6.0 requires python>=3.12
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ This project aims to keep compatibility with the supported Django releases.
 As such our versions of python and django are designed to match that cadence as much as possible.
 
 
-We are currently compatible with Django 5. Python versions 3.8 to 3.11.
+We are currently compatible with Django 4.2 to 6 and Python 3.10 to 3.13 (Django 6.0 requires Python 3.12 or newer).
 
 Documentation
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django>=4.0,<6
+Django>=4.2,<7
 Sphinx>=1.2.0
 phonenumbers>=7.0.2
-django-phonenumber-field==6.1.0
+django-phonenumber-field[phonenumbers]>=8.4.0
 twilio>=7
 wheel>=0.22.0
 setuptools>=36.2

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,6 @@ from __future__ import unicode_literals, absolute_import
 from os.path import abspath, dirname, join, normpath
 
 from setuptools import find_packages, setup
-import sys
-
-
-INSTALL_PYTHON_REQUIRES = []
-# We are intending to keep up to date with the supported Django versions.
-# For the official support, please visit:
-# https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-if (py_minor_version := sys.version_info.minor) in [8, 9, 10, 11]:
-    django_python_version_install = (
-        f"Django>=4.0,<{'6' if py_minor_version >= 10 else '5'}"
-    )
-    INSTALL_PYTHON_REQUIRES.append(django_python_version_install)
 
 setup(
 
@@ -27,13 +15,15 @@ setup(
     zip_safe=False,
     include_package_data=True,
 
+    python_requires='>=3.10',
     # Package dependencies:
     install_requires=[
         'setuptools>=36.2',
         'twilio>=7',
-        'django-phonenumber-field>=0.6',
+        'Django>=4.2,<7',
+        'django-phonenumber-field[phonenumbers]>=8.4.0',
         'phonenumbers>=8.10.22',
-    ] + INSTALL_PYTHON_REQUIRES,
+    ],
 
     # Metadata for PyPI:
     author='Randall Degges',
@@ -54,18 +44,21 @@ setup(
     },
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
         'Intended Audience :: Developers',
         'License :: Public Domain',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,15 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist =
+    py{310,311}-django{42,51,52}
+    py{312,313}-django{42,51,52,60}
 skip_missing_interpreters = true
 [testenv]
 deps =
     -rrequirements.txt
     -rtest_requirements.txt
+    django42: Django>=4.2,<4.3
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
 commands=
     pytest


### PR DESCRIPTION
I added support for Django 6 to this project but with couple of tradeoffs:
- I dropped support for EOL python versions 3.8 and 3.9
- I updated minimum `django-phonenumber-field` package version because it support Django 6 only in the latest version - 8.4.0.

Let me know if anything needs to be сhanged.